### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM supervisely/base-py-sdk:6.72.55
+FROM supervisely/base-py-sdk:6.73.564
 
 COPY dev_requirements.txt dev_requirements.txt
 RUN pip install -r dev_requirements.txt

--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
 	],
 	"description": "Build labels distribution heatmap for dataset.",
 	"docker_image": "supervisely/visualization-stats:6.73.564",
-	"instance_version": "6.9.22",
+	"instance_version": "6.15.60",
 	"main_script": "src/main.py",
 	"gui_template": "src/gui.html",
 	"task_location": "workspace_tasks",

--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
 		"visualization stats"
 	],
 	"description": "Build labels distribution heatmap for dataset.",
-	"docker_image": "supervisely/visualization-stats:6.73.104",
+	"docker_image": "supervisely/visualization-stats:6.73.564",
 	"instance_version": "6.9.22",
 	"main_script": "src/main.py",
 	"gui_template": "src/gui.html",

--- a/config.json
+++ b/config.json
@@ -1,26 +1,28 @@
 {
-	"name": "Labels spatial distribution",
-	"type": "app",
-	"categories": [
-		"images",
-		"visualization",
-		"exploration",
-		"statistics",
-		"visualization stats"
-	],
-	"description": "Build labels distribution heatmap for dataset.",
-	"docker_image": "supervisely/visualization-stats:6.73.564",
-	"instance_version": "6.15.60",
-	"main_script": "src/main.py",
-	"gui_template": "src/gui.html",
-	"task_location": "workspace_tasks",
-	"isolate": true,
-	"context_menu": {
-		"target": ["images_project"],
-		"context_root": "Report"
-	},
-	"icon": "https://i.imgur.com/hH7CUDa.png",
-	"icon_cover": true,
-	"icon_background": "#FFFFFF",
-	"poster": "https://i.imgur.com/MGi3NXG.jpg"
+  "name": "Labels spatial distribution",
+  "type": "app",
+  "categories": [
+    "images",
+    "visualization",
+    "exploration",
+    "statistics",
+    "visualization stats"
+  ],
+  "description": "Build labels distribution heatmap for dataset.",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "instance_version": "6.15.60",
+  "main_script": "src/main.py",
+  "gui_template": "src/gui.html",
+  "task_location": "workspace_tasks",
+  "isolate": true,
+  "context_menu": {
+    "target": [
+      "images_project"
+    ],
+    "context_root": "Report"
+  },
+  "icon": "https://i.imgur.com/hH7CUDa.png",
+  "icon_cover": true,
+  "icon_background": "#FFFFFF",
+  "poster": "https://i.imgur.com/MGi3NXG.jpg"
 }

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.104
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
